### PR TITLE
fix: Update Spanish translations

### DIFF
--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1,24 +1,46 @@
-[{
-  "i18n": "es",
-  "ns": "reaction-i18n",
-  "translation": {
-    "reaction-i18n": {
-      "admin": {
-        "i18nSettings": {
-          "shopLocalization": "Localización de tiendas",
-          "enabledCurrencies": "Monedas",
-          "enabledLanguages": "Idiomas",
-          "allOn": "todos de la",
-          "allOff": "Todo apagado"
-        },
-        "baseUOM": "Unidad de medida base",
-        "currency": "Divisa base",
-        "currencyTooltip": "Divisa predeterminada",
-        "language": "Idioma base",
-        "languageTooltip": "Se utilizará este idioma si el sistema de detección de idiomas del dispositivo falla",
-        "timezone": "Zonha horaria",
-        "timezoneOptions": "Elegir zona horaria"
+[
+  {
+    "i18n": "es",
+    "ns": "reaction-i18n",
+    "translation": {
+      "reaction-i18n": {
+        "admin": {
+          "i18nSettings": {
+            "shopLocalization": "Localización de la tienda",
+            "enabledCurrencies": "Monedas",
+            "enabledLanguages": "Idiomas",
+            "allOn": "Todo encendido",
+            "allOff": "Todo apagado",
+            "reloadTranslations": "Recargar traducciones",
+            "reloadStarted": "Recargando traducciones para la tienda actual.",
+            "reloadAllStarted": "Recargando traducciones para todas las tiendas.",
+            "reloadSuccess": "Se han recargado las traducciones para la tienda actual.",
+            "reloadAllSuccess": "Se han recargado las traducciones para todas las tiendas.",
+            "reloadError": "No se pudieron recargar las traducciones para la tienda actual.",
+            "reloadAllError": "No se pudieron recargar las traducciones para todas las tiendas."
+          },
+          "baseUOL": "Unidad Base de Longitud",
+          "baseUOM": "Unidad Base de Medida",
+          "uol": {
+            "Inches": "Pulgadas",
+            "Centimeters": "Centímetros",
+            "Feet": "Pies"
+          },
+          "uom": {
+            "oz": "Onzas",
+            "lb": "Libras",
+            "g": "Gramos",
+            "kg": "Kilogramos"
+          },
+          "currency": "Moneda",
+          "currencyTooltip": "Moneda predeterminada de la tienda",
+          "language": "Idioma",
+          "languagePlaceholder": "Idioma",
+          "languageTooltip": "Este idioma se usará si falla la detección del idioma del dispositivo",
+          "timezone": "Zona horaria",
+          "timezoneLabel": "Elija una zona horaria"
+        }
       }
     }
   }
-}]
+]


### PR DESCRIPTION
Signed-off-by: Matias Zuniga <matias.nicolas.zc@gmail.com>

Impact: **minor**
Type: **bugfix**

## Issue
The i18n panel from reaction-admin was missing the spanish translations for the units of measure

## Solution
Update spanish translation of the api-plugin-i18n package. This was created from a clean copy of en.json.

I was in doubt about the baseUOM translation; that's because it represents "unidades de masa" -mass units- (commonly called "unidades de peso" -weight units-). However, i chose "unidad de medida", that is the translation of the "unit of measurement" name used in the original string.

## Breaking changes
None